### PR TITLE
Add styles for product post page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem "sass-rails"
 
 gem 'bootstrap-sass', '~> 3.4.1'
 
+gem 'kaminari'
+
 gem 'simple_form'
 
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,18 @@ GEM
       thor (>= 0.14, < 2.0)
     jsbundling-rails (1.0.2)
       railties (>= 6.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -299,6 +311,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   jsbundling-rails
+  kaminari
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.3)

--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -6,7 +6,9 @@
 }
 
 .container__card {
+  align-items: center;
   display: flex;
+  flex-direction: column;
   padding-bottom: 15px;
   width: 100%;
 }
@@ -21,9 +23,13 @@
     display: flex;
     height: 300px;
     justify-content: center;
+    max-height: 247px;
+    max-width: 370px;
     width: 100%;
 
     img {
+      max-height: 247px;
+      max-width: 370px;
       object-fit: cover;
     }
   }
@@ -81,6 +87,18 @@
   gap: 1rem;
   justify-content: end;
 
+  &:hover {
+    a,i {
+      color: $primary-green;
+    }
+
+    i {
+      margin-left: 10px;
+      transform: rotate(-90deg);
+      transition: all ease .5s;
+    }
+  }
+
   a,i {
     color: $text-gray;
     text-decoration: none;
@@ -101,5 +119,23 @@
 
   h2 {
     text-transform: capitalize;
+  }
+}
+
+.posts {
+  flex-wrap: wrap;
+
+  &__title{
+    max-width: 30%;
+  }
+
+  hr {
+    margin-top: 0;
+  }
+
+  h1 {
+    color: $logo-yellow;
+    margin-top: 6rem;
+    margin-bottom: 5px;
   }
 }

--- a/app/assets/stylesheets/components/_carousel.scss
+++ b/app/assets/stylesheets/components/_carousel.scss
@@ -2,7 +2,7 @@
   display: flex;
   margin: 50px;
   justify-content: space-between;
-  gap: 16px;
+  gap: 40px;
 }
 
 .carousel-control-prev,

--- a/app/assets/stylesheets/components/_post_form.scss
+++ b/app/assets/stylesheets/components/_post_form.scss
@@ -62,6 +62,11 @@
       font-weight: 700;
     }
 
+    span {
+      font-weight: 100;
+      font-size: 10px;
+    }
+
 
     textarea {
       border-radius: 5px;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
   before_action :set_ranking, only: %i[ show ]
   # GET /posts or /posts.json
   def index
-    @posts = Post.all
+    @posts = Post.page params[:page]
   end
 
   # GET /posts/1 or /posts/1.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,7 +37,7 @@ class UsersController < ApplicationController
   def purchases
     @bought = current_user.orders.all.order("created_at DESC")
   end
-    
+
   def sold
     @sold = current_user.posts.all.order("created_at DESC").select {|p| p.order_details.length >= 1}
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
   has_one_attached :avatar
   has_one_attached :cover_photo
 
+  paginates_per 10
+
   def published_products
     self.posts.count
   end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -35,11 +35,11 @@
 
 
     <div class="form_post__field">
-      <p>Agregar imagenes</p>
+      <p>Agregar imagenes <span>(370 x 247)</span></p>
       <span class="form_post--alert_error"><%= @post.errors.full_messages_for(:picture)[0] if @post.errors.has_key?(:picture) %></span>
       <div>
         <%= f.label :picture, class: "form_post__field--hover" do %>
-          <span class="form_post__add_items" id="add">+</span>
+          <div class="form_post__add_items" id="add">+</div>
           <%=  f.file_field :picture, multiple: true,  onchange: 'loadFiles(event)', class: "form_post__field--input", accept: 'image/png,image/jpeg' %>
         <% end %>
       </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,8 +1,30 @@
-<div id="<%= dom_id post %>">
-    <%= post.title%>
-    <%= post.description%>
-    <% post.picture.each do |file| %>
+<div class="card">
+  <div id="<%= dom_id post %>">
+    <div class="card__image">
+      <% post.picture.each do |file| %>
         <%= image_tag url_for(file) %>
-    <% end %>
-    <%= post.price%>
+      <% end %>
+    </div>
+    <h2><%= link_to post.title, post_path(post.id) %></h2>
+    <div class="card__features">
+      <i class="fa-solid fa-tag"></i>
+      <p>Hogar,</p>
+      <p>Limpieza </p>
+    </div>
+    <div class="card__container-price">
+      <span class="card--price">$<%= post.price %>.00 </span>
+    </div>
+    <div class="stars">
+      <% post.get_ranking.to_i.times do %>
+        <i class="fa-solid fa-star star--active"></i>
+      <% end %>
+      <%=post.post_comments.count%> opiniones
+    </div>
+    <p class="card--info"><%= truncate( post.description, length:85) %> </p>
+    <div class="card__more-info">
+      <%= link_to "Ver mas", post_path(post.id) %>
+      <i class="fa-solid fa-circle-arrow-down"></i>
+    </div>
+
+  </div>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,14 +1,20 @@
-<p style="color: green"><%= notice %></p>
+<div class="posts">
+  <div class="posts__title">
+    <h1>Publicaciones</h1>
+    <hr>
+  </div>
 
-<h1>Posts</h1>
+  <div class="container__card">
+    <div class="render__cards posts">
+      <% @posts.each do |post| %>
+        <%= render post %>
+      <% end %>
+    </div>
+    <%= paginate @posts%>
+  </div>
+<%= link_to "New post", new_post_path %>
 
-<div id="posts">
-  <% @posts.each do |post| %>
-    <%= render post %>
-    <p>
-      <%= link_to "Show this post", post %>
-    </p>
-  <% end %>
 </div>
 
-<%= link_to "New post", new_post_path %>
+
+

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 6
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
# Description
 - What?: Styles are added for the part of the posts made by the user, where a list of posts is displayed
 - Why?: This was implemented so that the user can better visualize the products that he has published in the app. See #112  for more information.
 
  ## Screenshots 
![posts](https://user-images.githubusercontent.com/39254580/170625384-3d9e8027-60fd-45fb-8f68-42da67637ab2.gif)

